### PR TITLE
libticables2: Add ppc64le to list of supported architectures

### DIFF
--- a/libticables/trunk/configure.ac
+++ b/libticables/trunk/configure.ac
@@ -160,6 +160,7 @@ case "$host" in
   mipsel-*-linux-*)      ARCH="-D__MIPS__ -D__LINUX__" ;;
   powerpc-*-linux-*)     ARCH="-D__PPC__  -D__LINUX__" ;;
   powerpc64-*-linux-*)   ARCH="-D__PPC__  -D__LINUX__" ;;
+  powerpc64le-*-linux-*) ARCH="-D__PPC__  -D__LINUX__" ;;
   powerpc-apple-darwin*) ARCH="-D__PPC__  -D__MACOSX__" ;;
   powerpc64-apple-darwin*) ARCH="-D__PPC__  -D__MACOSX__" ;;
   s390*-*-linux-*)       ARCH="-D__LINUX__" ;;


### PR DESCRIPTION
This adds ppc64le or powerpc64le (Little Endian PowerPC 64) to the list of architectures in configure.ac.

This patch originally came from the Fedora PowerPC team in order to get libticables2 1.3.4 to build on ppc64le. I forgot about it until building libticables2 1.3.5 for current Fedora Rawhide, when I noticed it was still necessary.