### PR TITLE
libti*: use APT addons for linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,31 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      addons:
+        apt:
+          packages:
+            build-essential
+            git
+            autoconf
+            automake
+            autopoint
+            libtool
+            libglib2.0-dev
+            zlib1g-dev
+            libusb-1.0-0-dev
+            gettext
+            bison
+            flex
+            groff
+            texinfo
+            libarchive-dev
     - os: osx
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get head ; brew update ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ; fi
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gettext libarchive libtool glib libusb bison flex texinfo libiconv intltool ; brew link --force gettext libarchive ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq build-essential git autoconf automake autopoint libtool libglib2.0-dev zlib1g-dev libusb-1.0-0-dev gettext bison flex groff texinfo libarchive-dev ; fi
 
 script:
   - mkdir prefix


### PR DESCRIPTION
... instead of manual apt-get invocations.

This was actually from a patch of mine here https://github.com/debrouxl/tilibs/commit/c5eaf5d291962c90dea74e8619f42b9ececa3370 that was committed in the other branch