### PR TITLE
macos build improvements and fixes

### DIFF
--- a/libticables/trunk/src/macos/detect.c
+++ b/libticables/trunk/src/macos/detect.c
@@ -224,7 +224,7 @@ static int check_for_node_usability(const char *pathname)
 	{
 	    ticables_info(_("    is the user '%s' in the group '%s': no"), user, group);
 	    ticables_info(_("    => you should add your username at the group '%s' in '/etc/group'"), group);
-	    ticables_info(_("    => you will have to restart your session, too"), group);
+	    ticables_info(_("    => you will have to restart your session, too"));
 	    free(user);
 	    free(group);
 

--- a/libticonv/trunk/src/Makefile.am
+++ b/libticonv/trunk/src/Makefile.am
@@ -25,5 +25,7 @@ if OS_WIN32
 endif
 
 if OS_MAC
+  libticonv_la_CPPFLAGS += -I/usr/local/opt/libiconv/include/
+  libticonv_la_LDFLAGS += -L/usr/local/opt/libiconv/lib/
   libticonv_la_LIBADD += -liconv
 endif

--- a/libticonv/trunk/src/iconv.c
+++ b/libticonv/trunk/src/iconv.c
@@ -31,9 +31,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <glib.h>
-#if defined(__MACOSX__)
-#  define LIBICONV_PLUG
-#endif
 #include <iconv.h>
 #include <errno.h>
 


### PR DESCRIPTION
1) error: data argument not used by format string [-Werror,-Wformat-extra-args]
2) use brew's more up-to-date libiconv (also makes it able to build statically). Also see https://github.com/debrouxl/tilp_and_gfm/pull/17