### PR TITLE
cmake: set soversion for all shared libraries

### DIFF
--- a/libticables/trunk/CMakeLists.txt
+++ b/libticables/trunk/CMakeLists.txt
@@ -49,6 +49,8 @@ set(TICABLES_LIBUSB_REQUIRES_PRIVATE "libusb-1.0")
 # auto-creation of all targets with flags etc.
 create_targets_both_lib_types(ticables2)
 
+set_target_properties(ticables2_shared PROPERTIES SOVERSION 8.0.0)
+
 # Takes care of the i18n po/pot/gmo/mo files
 if(ENABLE_NLS)
     i18n_mo_from_po_pot()

--- a/libticalcs/trunk/CMakeLists.txt
+++ b/libticalcs/trunk/CMakeLists.txt
@@ -69,6 +69,8 @@ try_static_libs_if_needed()
 # auto-creation of all targets with flags etc., alongside with internal deps
 create_targets_both_lib_types(ticalcs2 tifiles2 ticables2 ticonv)
 
+set_target_properties(ticalcs2_shared PROPERTIES SOVERSION 13.3.0)
+
 if(TRY_STATIC_LIBS)
     find_package(BZip2 REQUIRED) # Needed for some reason
     target_link_libraries(ticalcs2_shared ${BZIP2_LIBRARIES})

--- a/libticonv/trunk/CMakeLists.txt
+++ b/libticonv/trunk/CMakeLists.txt
@@ -32,6 +32,8 @@ try_static_libs_if_needed()
 # auto-creation of all targets with flags etc., alongside with internal deps
 create_targets_both_lib_types(ticonv)
 
+set_target_properties(ticonv_shared PROPERTIES SOVERSION 9.4.0)
+
 if(USE_ICONV)
     find_package(Iconv REQUIRED)
     # flags/link for external deps

--- a/libtifiles/trunk/CMakeLists.txt
+++ b/libtifiles/trunk/CMakeLists.txt
@@ -57,6 +57,8 @@ try_static_libs_if_needed()
 # auto-creation of all targets with flags etc., alongside with internal deps
 create_targets_both_lib_types(tifiles2 ticonv)
 
+set_target_properties(tifiles2_shared PROPERTIES SOVERSION 11.2.0)
+
 if(TRY_STATIC_LIBS)
     find_package(BZip2 REQUIRED) # Needed for some reason
     target_link_libraries(tifiles2_shared ${BZIP2_LIBRARIES})


### PR DESCRIPTION
Currently the cmake build system doesn't define soversion, which leads to all libraries being installed as just `lib*.so`. Set soversion to the same value defined in the autotools build system, so the shared libraries can be installed with the appropriate name (e.g. `libticonv.so.9.4.0` instead of `libticonv.so`).