### PR TITLE
libticables: add cmake check for parallel and serial includes

### DIFF
--- a/libticables/trunk/CMakeLists.txt
+++ b/libticables/trunk/CMakeLists.txt
@@ -61,7 +61,15 @@ if(ENABLE_NLS)
 endif()
 
 # additional internal defines
-target_compile_definitions(ticables2_objlib PUBLIC HAVE_LIBUSB_1_0=1 HAVE_LIBUSB10_STRERROR=1 HAVE_TERMIOS_H=1 HAVE_LINUX_PARPORT_H=${HAVE_LINUX_PARPORT_H} HAVE_LINUX_SERIAL_H=${HAVE_LINUX_SERIAL_H})
+target_compile_definitions(ticables2_objlib PUBLIC HAVE_LIBUSB_1_0=1 HAVE_LIBUSB10_STRERROR=1 HAVE_TERMIOS_H=1)
+
+# check includes for parallel and serial support
+if (HAVE_LINUX_PARPORT_H)
+    target_compile_definitions(ticables2_objlib PUBLIC HAVE_LINUX_PARPORT_H=1)
+endif()
+if (HAVE_LINUX_SERIAL_H)
+    target_compile_definitions(ticables2_objlib PUBLIC HAVE_LINUX_SERIAL_H=1)
+endif()
 
 # public export define
 target_compile_definitions(ticables2_objlib PUBLIC TICABLES_EXPORTS)

--- a/libticables/trunk/CMakeLists.txt
+++ b/libticables/trunk/CMakeLists.txt
@@ -41,6 +41,11 @@ set(PUBLIC_HEADERS
 # external deps lookup
 pkg_check_modules(DEPS REQUIRED glib-2.0 libusb-1.0>=1.0.16)
 
+# check includes for parallel and serial support
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE(linux/parport.h HAVE_LINUX_PARPORT_H)
+CHECK_INCLUDE_FILE(linux/serial.h HAVE_LINUX_SERIAL_H)
+
 try_static_libs_if_needed()
 
 # Needed for the .pc files configured in the function below.
@@ -56,7 +61,7 @@ if(ENABLE_NLS)
 endif()
 
 # additional internal defines
-target_compile_definitions(ticables2_objlib PUBLIC HAVE_LIBUSB_1_0=1 HAVE_LIBUSB10_STRERROR=1 HAVE_TERMIOS_H=1)
+target_compile_definitions(ticables2_objlib PUBLIC HAVE_LIBUSB_1_0=1 HAVE_LIBUSB10_STRERROR=1 HAVE_TERMIOS_H=1 HAVE_LINUX_PARPORT_H=${HAVE_LINUX_PARPORT_H} HAVE_LINUX_SERIAL_H=${HAVE_LINUX_SERIAL_H})
 
 # public export define
 target_compile_definitions(ticables2_objlib PUBLIC TICABLES_EXPORTS)


### PR DESCRIPTION
Check for the includes for parallel and serial support and set the relevant defines, so that support can be compiled in when available.