### PR TITLE
Some fixes for CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,8 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(GLOBAL_COMPILE_FLAGS "-W -Wall -Wextra -Wno-unused-parameter -Werror=shadow -Werror=write-strings -Wredundant-decls -Werror=declaration-after-statement -Werror=implicit-function-declaration -Werror=date-time -Werror=missing-prototypes -Werror=return-type -Werror=pointer-arith ")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${GLOBAL_COMPILE_FLAGS}")
+set(GLOBAL_COMPILE_FLAGS "-W -Wall -Wextra -Wno-unused-parameter -Werror=shadow -Werror=write-strings -Wredundant-decls -Werror=date-time -Werror=return-type -Werror=pointer-arith")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${GLOBAL_COMPILE_FLAGS} -Werror=declaration-after-statement -Werror=implicit-function-declaration -Werror=missing-prototypes")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GLOBAL_COMPILE_FLAGS}")
 
 if(APPLE)

--- a/libticables/trunk/CMakeLists.txt
+++ b/libticables/trunk/CMakeLists.txt
@@ -54,7 +54,7 @@ set(TICABLES_LIBUSB_REQUIRES_PRIVATE "libusb-1.0")
 # auto-creation of all targets with flags etc.
 create_targets_both_lib_types(ticables2)
 
-set_target_properties(ticables2_shared PROPERTIES SOVERSION 8.0.0)
+set_target_properties(ticables2_shared PROPERTIES VERSION 8.0.0 SOVERSION 8)
 
 # Takes care of the i18n po/pot/gmo/mo files
 if(ENABLE_NLS)

--- a/libticables/trunk/tests/CMakeLists.txt
+++ b/libticables/trunk/tests/CMakeLists.txt
@@ -8,17 +8,13 @@ add_executable(test_ticables_2 test_ticables_2.cc)
 
 pkg_check_modules(DEPS REQUIRED glib-2.0)
 
-set(internal_libdir "-L${CMAKE_BINARY_DIR}/libticables/trunk")
-
 foreach(tar torture_ticables test_ticables_2)
-    add_dependencies(${tar} ticables2_shared)
-
     target_compile_options(${tar} PRIVATE ${DEPS_CFLAGS})
 
     target_include_directories(${tar} PRIVATE
         ${CMAKE_SOURCE_DIR}/libticables/trunk/src)
 
-    target_link_libraries(${tar} "${internal_libdir}" ticables2 "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES})
+    target_link_libraries(${tar} ticables2_shared "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES})
 endforeach()
 
 set(builddirlibpaths "${CMAKE_BINARY_DIR}/libticables/trunk")

--- a/libticalcs/trunk/CMakeLists.txt
+++ b/libticalcs/trunk/CMakeLists.txt
@@ -69,7 +69,7 @@ try_static_libs_if_needed()
 # auto-creation of all targets with flags etc., alongside with internal deps
 create_targets_both_lib_types(ticalcs2 tifiles2 ticables2 ticonv)
 
-set_target_properties(ticalcs2_shared PROPERTIES SOVERSION 13.3.0)
+set_target_properties(ticalcs2_shared PROPERTIES VERSION 13.0.3 SOVERSION 13)
 
 if(TRY_STATIC_LIBS)
     find_package(BZip2 REQUIRED) # Needed for some reason

--- a/libticalcs/trunk/tests/CMakeLists.txt
+++ b/libticalcs/trunk/tests/CMakeLists.txt
@@ -8,14 +8,7 @@ add_executable(test_ticalcs_2 test_ticalcs_2.cc)
 
 pkg_check_modules(DEPS REQUIRED glib-2.0)
 
-set(internal_libdir "-L${CMAKE_BINARY_DIR}/libticonv/trunk \
-                     -L${CMAKE_BINARY_DIR}/libtifiles/trunk \
-                     -L${CMAKE_BINARY_DIR}/libticables/trunk \
-                     -L${CMAKE_BINARY_DIR}/libticalcs/trunk")
-
 foreach(tar torture_ticalcs test_ticalcs_2)
-    add_dependencies(${tar} ticalcs2_shared)
-
     target_compile_options(${tar} PRIVATE ${DEPS_CFLAGS})
 
     target_include_directories(${tar} PRIVATE
@@ -24,7 +17,7 @@ foreach(tar torture_ticalcs test_ticalcs_2)
         ${CMAKE_SOURCE_DIR}/libticables/trunk/src
         ${CMAKE_SOURCE_DIR}/libticalcs/trunk/src)
 
-    target_link_libraries(${tar} "${internal_libdir}" ticonv tifiles2 ticables2 ticalcs2 "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES})
+    target_link_libraries(${tar} ticonv_shared tifiles2_shared ticables2_shared ticalcs2_shared "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES})
 endforeach()
 
 set(builddirlibpaths "${CMAKE_BINARY_DIR}/libticonv/trunk:${CMAKE_BINARY_DIR}/libtifiles/trunk:${CMAKE_BINARY_DIR}/libticables/trunk:${CMAKE_BINARY_DIR}/libticalcs/trunk")

--- a/libticonv/trunk/CMakeLists.txt
+++ b/libticonv/trunk/CMakeLists.txt
@@ -32,7 +32,7 @@ try_static_libs_if_needed()
 # auto-creation of all targets with flags etc., alongside with internal deps
 create_targets_both_lib_types(ticonv)
 
-set_target_properties(ticonv_shared PROPERTIES SOVERSION 9.4.0)
+set_target_properties(ticonv_shared PROPERTIES VERSION 9.0.4 SOVERSION 9)
 
 if(USE_ICONV)
     find_package(Iconv REQUIRED)

--- a/libticonv/trunk/tests/CMakeLists.txt
+++ b/libticonv/trunk/tests/CMakeLists.txt
@@ -8,17 +8,13 @@ add_executable(test_ticonv test_ticonv.cc)
 
 pkg_check_modules(DEPS REQUIRED glib-2.0)
 
-set(internal_libdir "-L${CMAKE_BINARY_DIR}/libticonv/trunk")
-
 foreach(tar torture_ticonv test_ticonv)
-    add_dependencies(${tar} ticonv_shared)
-
     target_compile_options(${tar} PRIVATE ${DEPS_CFLAGS})
 
     target_include_directories(${tar} PRIVATE
         ${CMAKE_SOURCE_DIR}/libticonv/trunk/src)
 
-    target_link_libraries(${tar} "${internal_libdir}" ticonv "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES})
+    target_link_libraries(${tar} ticonv_shared "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES})
 endforeach()
 
 set(builddirlibpaths "${CMAKE_BINARY_DIR}/libticonv/trunk")

--- a/libtifiles/trunk/CMakeLists.txt
+++ b/libtifiles/trunk/CMakeLists.txt
@@ -57,7 +57,7 @@ try_static_libs_if_needed()
 # auto-creation of all targets with flags etc., alongside with internal deps
 create_targets_both_lib_types(tifiles2 ticonv)
 
-set_target_properties(tifiles2_shared PROPERTIES SOVERSION 11.2.0)
+set_target_properties(tifiles2_shared PROPERTIES VERSION 11.0.2 SOVERSION 11)
 
 if(TRY_STATIC_LIBS)
     find_package(BZip2 REQUIRED) # Needed for some reason

--- a/libtifiles/trunk/tests/CMakeLists.txt
+++ b/libtifiles/trunk/tests/CMakeLists.txt
@@ -8,19 +8,14 @@ add_executable(test_tifiles_2 test_tifiles_2.cc)
 
 pkg_check_modules(DEPS REQUIRED glib-2.0)
 
-set(internal_libdir "-L${CMAKE_BINARY_DIR}/libticonv/trunk \
-                     -L${CMAKE_BINARY_DIR}/libtifiles/trunk")
-
 foreach(tar torture_tifiles test_tifiles_2)
-    add_dependencies(${tar} tifiles2_shared)
-
     target_compile_options(${tar} PRIVATE ${DEPS_CFLAGS})
 
     target_include_directories(${tar} PRIVATE
         ${CMAKE_SOURCE_DIR}/libticonv/trunk/src
         ${CMAKE_SOURCE_DIR}/libtifiles/trunk/src)
 
-    target_link_libraries(${tar} "${internal_libdir}" ticonv tifiles2 "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES})
+    target_link_libraries(${tar} ticonv_shared tifiles2_shared "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES})
 endforeach()
 
 set(builddirlibpaths "${CMAKE_BINARY_DIR}/libticonv/trunk:${CMAKE_BINARY_DIR}/libtifiles/trunk")


### PR DESCRIPTION
See commits for details.

I wonder whether the `VERSION` for shared library targets should just use `${PROJECT_VERSION}` instead or be omitted altogether. Using libtool's current:age:revision calculation is a bit weird.