### PR TITLE
libtifiles: Fix tifiles_create_table_of_entries

### DIFF
--- a/libticables/trunk/src/ticables.h
+++ b/libticables/trunk/src/ticables.h
@@ -238,7 +238,7 @@ typedef struct _CableHandle  CableHandle;
  * @set_d0: set D0/red wire
  * @set_d1: set D1/white wire
  * @get_d0 get D0/red wire
- * @get_d1 set D1/red wire
+ * @get_d1 set D1/white wire
  * @set_raw: set both wires
  * @get_raw: read both wires
  *

--- a/libtifiles/trunk/src/filesxx.cc
+++ b/libtifiles/trunk/src/filesxx.cc
@@ -905,8 +905,8 @@ TIEXPORT2 int** tifiles_create_table_of_entries(FileContent *content, unsigned i
 			{		// add new folder entry
 				folder_list[num_folders] = (char *) g_malloc0(257);
 				//printf("%i: adding '%s'\n", num_folders, entry->folder);
-				strncpy(folder_list[num_folders], entry->folder, sizeof(folder_list[num_folders]) - 1);
-				folder_list[num_folders][sizeof(folder_list[num_folders]) - 1] = 0;
+				strncpy(folder_list[num_folders], entry->folder, 257 - 1);
+				folder_list[num_folders][257 - 1] = 0;
 				folder_list[num_folders + 1] = NULL;
 				num_folders++;
 			}


### PR DESCRIPTION
The port from strcpy to strncpy errorneously used sizeof on a heap allocated
array, which doesn't have the expected result. This broke e.g. saving variables
to files, which were empty beyond the header.

+ a typo fix