### PR TITLE
Remove const from default_update

### DIFF
--- a/libticalcs/trunk/src/probe.cc
+++ b/libticalcs/trunk/src/probe.cc
@@ -392,7 +392,7 @@ static int ticalcs_probe_calc_1(CalcHandle* handle, CalcModel* model)
 	return ret;
 }
 
-extern const CalcUpdate default_update;
+extern CalcUpdate default_update;
 
 /**
  * ticalcs_probe_calc:

--- a/libticalcs/trunk/src/ticalcs.cc
+++ b/libticalcs/trunk/src/ticalcs.cc
@@ -43,7 +43,7 @@
 /* Internal data */
 /*****************/
 
-extern const CalcUpdate default_update;
+extern CalcUpdate default_update;
 
 static CalcFncts const *const calcs[] =
 {

--- a/libticalcs/trunk/src/update.cc
+++ b/libticalcs/trunk/src/update.cc
@@ -27,7 +27,7 @@ static void ticalcs_default_update_refresh(void){};
 static void ticalcs_default_update_pbar(void)	{};
 static void ticalcs_default_update_label(void)	{};
 
-extern const CalcUpdate default_update =
+CalcUpdate default_update =
 {
 	"", 0,
 	0.0, 0, 0, 0, 0, 0, 0, (1 << 0), 0,


### PR DESCRIPTION
It is actually written to, so instead of adding const where it's missing (what
6bdf559967 did), remove it everywhere.