### PR TITLE
link_usb1: fix libusb include for fresh/clean install of macOS deps.

### DIFF
--- a/libticables/trunk/src/linux/link_usb1.cc
+++ b/libticables/trunk/src/linux/link_usb1.cc
@@ -39,7 +39,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
-#ifdef __BSD__
+#if defined(__BSD__) || defined(__MACOSX__)
 #include <libusb.h>
 #else
 #include <libusb-1.0/libusb.h>


### PR DESCRIPTION
pkg-config gives `-L[...]/include/libusb-1.0` so no need to have the folder in the brackets.
The <libusb-1.0/libusb.h> path seemed to be valid for some old installs...

Originally found by @LogicalJoe on a M1 machine, repro'd locally by myself on a M1 MBA as well; still works fine on an intel macOS.