### PR TITLE
[WIP] Add coverity scan workflow

### DIFF
--- a/.github/workflows/coverity
+++ b/.github/workflows/coverity
@@ -22,11 +22,14 @@ jobs:
         
     - name: Prepare build
       run: |
-        export PREBUILDER=autotools
-        export BUILDER=make
-        .travis/script.sh
+        mkdir prefix
+        prefixpath="$(pwd)/prefix"
+        export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${prefixpath}/lib/pkgconfig
+        mkdir build && cd build
+        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${prefixpath} ..
     
     - uses: vapier/coverity-scan-action@v1
       with:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        working-directory: "${{ github.workspace }}/build"

--- a/.github/workflows/coverity
+++ b/.github/workflows/coverity
@@ -1,0 +1,32 @@
+name: Coverity Scan
+
+# We only want to test official release code, not every pull request.
+on:
+  push:
+    branches: [master]
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Git Repo
+      uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: Install Linux dependencies (Ubuntu 18.04+)
+      run: |
+        set -e
+        sudo apt-get update
+        sudo apt-get build-essential git autoconf automake autopoint libtool libglib2.0-dev zlib1g-dev libusb-1.0-0-dev gettext bison flex groff texinfo libarchive-dev ninja-build liblz4-dev liblzma-dev
+        
+    - name: Prepare build
+      run: |
+        export PREBUILDER=autotools
+        export BUILDER=make
+        .travis/script.sh
+    
+    - uses: vapier/coverity-scan-action@v1
+      with:
+        email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+        token: ${{ secrets.COVERITY_SCAN_TOKEN }}


### PR DESCRIPTION
In the repo's settings, two secrets need to be added: `COVERITY_SCAN_EMAIL` and `COVERITY_SCAN_TOKEN`, obtainable from the coverity scan website.