### PR TITLE
libticables: fix compiler error, struct usb_device missing 'struct' keyword

### DIFF
--- a/libticables/trunk/src/linux/link_usb.cc
+++ b/libticables/trunk/src/linux/link_usb.cc
@@ -399,7 +399,7 @@ static int tigl_open(int id, usb_dev_handle **udh)
 		return ERR_LIBUSB_OPEN;
 	}
 
-	*udh = usb_open((usb_device *)(tigl_devices[id].dev));
+	*udh = usb_open((struct usb_device *)(tigl_devices[id].dev));
 	if (*udh != NULL) 
 	{
 		/* only one configuration: #1 */
@@ -504,7 +504,7 @@ static int slv_open(CableHandle *h)
 		return ret;
 	}
 	cable_info = tigl_devices[h->address];
-	uDev = (usb_device *)(tigl_devices[h->address].dev);
+	uDev = (struct usb_device *)(tigl_devices[h->address].dev);
 	uInEnd  = 0x81;
 	uOutEnd = 0x02;
 


### PR DESCRIPTION
when building for linux, the compiler gives the following errors which have been fixed in this commit:
`
linux/link_usb.cc:402:31: error: expected primary-expression before ‘)’ token
  402 |  *udh = usb_open((usb_device *)(tigl_devices[id].dev));
`
`
linux/link_usb.cc:507:22: error: expected primary-expression before ‘)’ token
  507 |  uDev = (usb_device *)(tigl_devices[h->address].dev);
`