### PR TITLE
libticables: use relative include paths

### DIFF
--- a/libticables/trunk/src/linux/ioports.cc
+++ b/libticables/trunk/src/linux/ioports.cc
@@ -46,9 +46,9 @@
 #include <errno.h>
 #include <string.h>
 
-#include "gettext.h"
-#include "error.h"
-#include "logging.h"
+#include "../gettext.h"
+#include "../error.h"
+#include "../logging.h"
 #include "ioports.h"
 
 #ifdef HAVE_LINUX_PARPORT_H


### PR DESCRIPTION
This completely removes the need to add an extra include path from a build system and additionally avoids accidentally including `/usr/include/error.h` instead.